### PR TITLE
Fix typo in settings widget message box

### DIFF
--- a/src/settingswidget/settingswidget.cpp
+++ b/src/settingswidget/settingswidget.cpp
@@ -324,7 +324,7 @@ void SettingsWidget::keyPressEvent(QKeyEvent *event) {
 void SettingsWidget::closeEvent(QCloseEvent *event) {
     if (_hotkeyManager->hotkeys().empty()){
         QMessageBox msgBox(QMessageBox::Critical, "Error",
-                           "Hotkey is invalid, please set it. Press Ok to go"\
+                           "Hotkey is invalid, please set it. Press Ok to go "\
                            "back to the settings, or press Cancel to quit albert.",
                            QMessageBox::Close|QMessageBox::Ok);
         msgBox.exec();


### PR DESCRIPTION
"goback" should be "go back"

![screen shot 2015-05-27 at 11 34 47](https://cloud.githubusercontent.com/assets/115889/7833116/8cffe5f2-0464-11e5-956d-8fd7f82dfdd5.png)
